### PR TITLE
Change default params es6 to traditional js

### DIFF
--- a/stopwatch.js
+++ b/stopwatch.js
@@ -113,7 +113,8 @@ Stopwatch.prototype.setElapsed = function(hours, mins, secs) {
 			this.tickResolution);
 	}
 }
-Stopwatch.prototype.toString = function(milliseconds = false) {
+Stopwatch.prototype.toString = function(milliseconds) {
+	var milliseconds = milliseconds || false;
 	var zpad = function(no, digits) {
 		no = no.toString();
 		while(no.length < digits)


### PR DESCRIPTION
For old browser doesn't support es6 default parameters so I decided to change es6 param to traditional js way. Sorry about that.